### PR TITLE
fix: remove codecov package from requirements

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,7 +3,6 @@
 -c constraints.txt
 -r base.txt
 
-codecov                   # Code coverage reporting
 pluggy
 tox
 tox-battery

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,25 +4,15 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.2
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -30,8 +20,6 @@ pluggy==1.0.0
     #   tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -43,8 +31,6 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via
     #   -r requirements/ci.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
@@ -14,8 +14,6 @@ bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
     # via requests
-cffi==1.15.1
-    # via cryptography
 chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.1.0
@@ -29,8 +27,6 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-cryptography==39.0.2
-    # via secretstorage
 diff-cover==7.5.0
     # via -r requirements/dev.in
 dill==0.3.6
@@ -48,13 +44,13 @@ edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
 edx-lint==5.3.4
     # via -r requirements/quality.in
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
 idna==3.4
     # via requests
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   twine
@@ -66,10 +62,6 @@ isort==5.12.0
     #   pylint
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   code-annotations
@@ -88,7 +80,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via tox
 path==16.6.0
     # via edx-i18n-tools
@@ -96,7 +88,7 @@ pbr==5.11.1
     # via stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   pylint
     #   virtualenv
@@ -111,16 +103,14 @@ py==1.11.0
     # via tox
 pycodestyle==2.10.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -136,7 +126,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via django
 pyyaml==6.0
     # via
@@ -152,10 +142,8 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -173,7 +161,7 @@ tomli==2.0.1
     # via
     #   pylint
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 tox==3.28.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,12 +14,8 @@ bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
     # via requests
-cffi==1.15.1
-    # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==39.0.2
-    # via secretstorage
 django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
@@ -38,7 +34,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   sphinx
@@ -47,10 +43,6 @@ importlib-resources==5.12.0
     # via keyring
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
 keyring==23.13.1
@@ -63,7 +55,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via sphinx
 pbr==5.11.1
     # via stevedore
@@ -71,15 +63,13 @@ pkginfo==1.9.6
     # via twine
 pockets==0.9.1
     # via sphinxcontrib-napoleon
-pycparser==2.21
-    # via cffi
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   doc8
     #   readme-renderer
     #   rich
     #   sphinx
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   babel
     #   django
@@ -98,10 +88,8 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
@@ -41,13 +41,13 @@ mccabe==0.7.0
     # via pylint
 pbr==5.11.1
     # via stevedore
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via pylint
 pycodestyle==2.10.0
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -63,7 +63,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via django
 pyyaml==6.0
     # via code-annotations
@@ -79,7 +79,7 @@ text-unidecode==1.3
     # via python-slugify
 tomli==2.0.1
     # via pylint
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,9 +4,7 @@
 #
 #    make upgrade
 #
-attrs==22.2.0
-    # via pytest
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via pytest-cov
 ddt==1.3.1
     # via -r requirements/test.in
@@ -14,11 +12,11 @@ exceptiongroup==1.1.1
     # via pytest
 iniconfig==2.0.0
     # via pytest
-packaging==23.0
+packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   pytest-cov
     #   pytest-django


### PR DESCRIPTION
### Description
- Codecov deprecated the pypi package long ago (Feb 2022) but left it up until now.
- Removing the package from requirements to fix the failing upgrade job.
- The Github Action we use to upload to codecov doesn't depend on the package so our CI coverage won't be affected by the change.