### PR TITLE
fix: remove tox-battery from requirements and update tox

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -5,5 +5,4 @@
 
 pluggy
 tox
-tox-battery
 virtualenv

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -22,19 +28,13 @@ pluggy==1.3.0
     # via
     #   -r requirements/ci.in
     #   tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==3.28.0
-    # via
-    #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.4
     # via -r requirements/ci.in
 virtualenv==20.25.0
     # via

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -6,7 +6,6 @@ diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
 pluggy
 tox
-tox-battery
 twine                     # Utility for PyPI package uploads
 virtualenv
 wheel                     # For generation of wheels for PyPI

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,12 +10,14 @@ astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
+cachetools==5.3.2
+    # via tox
 certifi==2023.11.17
     # via requests
-cffi==1.16.0
-    # via cryptography
 chardet==5.2.0
-    # via diff-cover
+    # via
+    #   diff-cover
+    #   tox
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
@@ -27,8 +29,8 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.5.0
     # via edx-lint
-cryptography==41.0.7
-    # via secretstorage
+colorama==0.4.6
+    # via tox
 diff-cover==8.0.1
     # via -r requirements/dev.in
 dill==0.3.7
@@ -64,10 +66,6 @@ isort==5.12.0
     #   pylint
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   code-annotations
@@ -110,12 +108,8 @@ pluggy==1.3.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-py==1.11.0
-    # via tox
 pycodestyle==2.11.1
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.17.2
@@ -137,6 +131,8 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
+pyproject-api==1.6.1
+    # via tox
 python-slugify==8.0.1
     # via code-annotations
 pytz==2023.3.post1
@@ -157,12 +153,8 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
-    # via
-    #   edx-lint
-    #   tox
+    # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
 sqlparse==0.4.4
@@ -178,11 +170,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.12.3
     # via pylint
-tox==3.28.0
-    # via
-    #   -r requirements/dev.in
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.4
     # via -r requirements/dev.in
 twine==4.0.2
     # via -r requirements/dev.in

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,12 +18,8 @@ beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
 certifi==2023.11.17
     # via requests
-cffi==1.16.0
-    # via cryptography
 charset-normalizer==3.3.2
     # via requests
-cryptography==41.0.7
-    # via secretstorage
 django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
@@ -50,10 +46,6 @@ importlib-resources==6.1.1
     # via keyring
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
 keyring==24.3.0
@@ -78,8 +70,6 @@ pkginfo==1.9.6
     # via twine
 pockets==0.9.1
     # via sphinxcontrib-napoleon
-pycparser==2.21
-    # via cffi
 pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
 pygments==2.17.2
@@ -111,8 +101,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   pockets


### PR DESCRIPTION
## Description
- Removed `tox-battery` from requirements since it is not needed with `toxv4` anymore.
- Updated `tox` to `v4`.