### PR TITLE
Feat: Add django 5.2 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python-version:
         - '3.11'
         - '3.12'
-        toxenv: [django42, docs, quality]
+        toxenv: [django42, django52, docs, quality]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,312}-django{42}, docs, quality
+envlist = py{311,312}-django{42,52}, docs, quality
 
 [pytest]
 addopts = --cov web_fragments --cov-report term-missing --cov-report xml
@@ -7,6 +7,7 @@ addopts = --cov web_fragments --cov-report term-missing --cov-report xml
 [testenv]
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 setenv =
     DJANGO_SETTINGS_MODULE = test_settings

--- a/web_fragments/__init__.py
+++ b/web_fragments/__init__.py
@@ -1,4 +1,4 @@
 """
 Web fragments.
 """
-__version__ = '3.0.0'
+__version__ = '3.1.0'

--- a/web_fragments/views.py
+++ b/web_fragments/views.py
@@ -22,7 +22,7 @@ class FragmentView(View, metaclass=ABCMeta):
         """
         fragment = self.render_to_fragment(request, **kwargs)
         response_format = request.GET.get('format') or request.POST.get('format') or 'html'
-        if response_format == 'json' or WEB_FRAGMENT_RESPONSE_TYPE in request.META.get('HTTP_ACCEPT', 'text/html'):
+        if response_format == 'json' or WEB_FRAGMENT_RESPONSE_TYPE in request.headers.get('accept', 'text/html'):
             return JsonResponse(fragment.to_dict())
 
         return self.render_standalone_response(request, fragment, **kwargs)


### PR DESCRIPTION
Resolved #262 

## Add Django 5.2 Support
This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

### Changes Made:
- Update ci and tox files
- Ran django-upgrade to apply necessary syntax updates for Django 5.2.
- Run tests using tox command and resolved the warning
- Ensured all modifications remain backward-compatible with Django 4.2.

### django-upgrade usage:
`git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`